### PR TITLE
Fix typo of demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,8 @@
   <pre>
   <code class="language-javascript line-numbers">import TagManager from 'tagmanager-wrap';
 
-  window.tagmanagerDatalayer = [];
-  const tagmanager = new TagManager(window.tagmanagerDatalayer, {
+  window.tagManagerDatalayer = [];
+  const tagmanager = new TagManager(window.tagManagerDatalayer, {
     gtmId: 'AAABBB000',
     startPush: {
       page_type: 'page:price',


### PR DESCRIPTION
On demo of wrapper, the text it's wrong on example
`window.tagmanagerDatalayer`

This text need to be
`window.tagManagerDatalayer`

This typo can couse some trouble when copy the code.