### PR TITLE
[WIP] Non-destructive transposition of this.dataLayer to window.tagManagerDataLayer

### DIFF
--- a/src/tagmanager-wrap.js
+++ b/src/tagmanager-wrap.js
@@ -70,7 +70,7 @@ export default class TagManager {
 
     document.body.appendChild(script);
 
-    Object.assign(window.tagManagerDataLayer, this.dataLayer);
+    this.dataLayer.map(window.tagManagerDataLayer.push);
 
     this.dataLayer = window.tagManagerDataLayer;
   }


### PR DESCRIPTION
Still need tests, but is here for the early code-review.

**CHANGELOG** :memo:
* The `Object.assign()` was pointed by @bernardosrulzon as destructive for the existing datalayer. This copies only the _contents_ of the datalayer into the right one.
